### PR TITLE
immediately inject element, use form wrapper to reset input each time

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,16 +6,13 @@
 module.exports = filePicker;
 
 /**
- * Reference to last `<input>` used.
+ * Input template
  */
 
-var last;
-
-/**
- * firefox feature detection
- */
-
-var firefox = (window.mozInnerScreenX !== undefined);
+var form = document.createElement('form');
+form.innerHTML = '<input type="file" style="top: -1000px; position: absolute">';
+document.body.appendChild(form);
+var input = form.children[0];
 
 /**
  * Opens a file picker dialog.
@@ -26,9 +23,7 @@ var firefox = (window.mozInnerScreenX !== undefined);
  */
 
 function filePicker(opts, fn){
-  if (last && last.parentNode) {
-    last.parentNode.removeChild(last);
-  }
+  form.reset();
 
   if ('function' == typeof opts) {
     fn = opts;
@@ -36,39 +31,16 @@ function filePicker(opts, fn){
   }
   opts = opts || {};
 
-  // inject input element
-  var input = document.createElement('input');
-  input.type = 'file';
-  input.style.top = '-100px';
-  input.style.position = 'absolute';
-  last = input;
-
   // multiple files support
   if (opts.multiple) input.multiple = true;
   if (opts.directory) input.webkitdirectory = input.mozdirectory = input.directory = true;
 
   // listen change event
-  input.addEventListener('change', function(ev){
+  input.addEventListener('change', function onchange(ev){
     fn(input.files, ev, input);
+    input.removeEventListener('change', onchange);
   });
 
-  // inject
-  document.body.appendChild(input);
-
-  if (firefox) {
-    input.click();
-  } else {
-    setTimeout(open, 0);
-  }
-
-  // open
-  function open(){
-    input.dispatchEvent(click());
-  }
-}
-
-function click() {
-  var evt = document.createEvent('MouseEvents');
-  evt.initEvent( 'click', true, true );
-  return evt;
+  // trigger input dialog
+  input.click();
 }


### PR DESCRIPTION
back to old API, since we can reset, there's no point in instantiating. Still gets the benefits of injecting DOM element well before triggering the click.
